### PR TITLE
Allow integers to be treated as floats when detemining column type

### DIFF
--- a/data-table.lisp
+++ b/data-table.lisp
@@ -315,7 +315,9 @@
               (cond
                 ((null current) (setf current type))
                 ((not (subtypep type current))
-                 (setf current (if (subtypep type 'double-float)
+                 (setf current (if (or
+                                    (subtypep type 'double-float)
+                                    (subtypep type 'integer))
                                    'double-float
                                    'string)))))))
         (collect (or current 'string))))))


### PR DESCRIPTION
When dealing with a column containing both float type values and
integer type values it's probably better to treat integers as floats
and end up with a numeric type instead of coercing everything to
strings.
