### PR TITLE
Add symbol as a type for column index

### DIFF
--- a/data-table.lisp
+++ b/data-table.lisp
@@ -74,7 +74,7 @@
 (defmethod relaxed-parse-float (str &key (type 'double-float))
   "trys to read a value we hope to be a floating point number returns nil on failure
 
-   The goal is to allow reading strings with spaces commas and dollar signs in them correctly 
+   The goal is to allow reading strings with spaces commas and dollar signs in them correctly
   "
   (etypecase str
     (null nil)
@@ -322,11 +322,12 @@
                    (type (simplify-types val)))
               (cond
                 ((null current) (setf current type))
+                ((eql 'string current) current)
                 ((not (subtypep type current))
                  (setf current (if (or
                                     (subtypep type 'double-float)
                                     (subtypep type 'integer))
-                                   'double-float
+                                     'double-float
                                    'string)))))))
         (collect (or current 'string))))))
 
@@ -398,6 +399,7 @@
   (etypecase col
     (null nil)
     (integer col)
+    (symbol (position col (column-names dt) :test #'eql))
     (string (position col (column-names dt) :test #'string-equal))))
 
 (defun column-type (col dt)

--- a/data-table.lisp
+++ b/data-table.lisp
@@ -306,30 +306,41 @@
                   (setf (aref sample r) row))))
         (finally (return (coerce sample 'list))))))
 
+(defun assign-types-to-column (column-values)
+  "Given a list of values `column-values', return a unique list of types present in that list."
+  (let ((types))
+    (iter (for val in column-values)
+      (alexandria:when-let (type (cond
+                                   ((null val) nil)
+                                   ((not (stringp val))
+                                    (simplify-types val))
+                                   ((not (trim-and-nullify val))
+                                    'string)
+                                   (t
+                                    (alexandria:if-let (type (simplify-types
+                                                              (or (maybe-apply '%to-clsql-date val)
+                                                                  (ignore-errors (parse-integer val))
+                                                                  (relaxed-parse-float val)
+                                                                  val)))
+                                      type
+                                      'string))))
+        (unless (member type types)
+          (push type types))))
+      types))
+
 (defun guess-types-for-data-table (data-table)
+  "Guess the types of each column of data in a data-table."
   (let ((trans (transpose-lists (sample-rows (rows data-table)))))
-    (iter (for i upfrom 0)
-      (for col in trans)
-      (let (current)
-        (iter (for val in col)
-          (when (and val (not (stringp val)))
-            (setf current (type-of val)))
-          (when (and val (stringp val) (trim-and-nullify val))
-            (let* ((val (or (maybe-apply '%to-clsql-date val)
-                            (ignore-errors (parse-integer val))
-                            (relaxed-parse-float val)
-                            val))
-                   (type (simplify-types val)))
-              (cond
-                ((null current) (setf current type))
-                ((eql 'string current) current)
-                ((not (subtypep type current))
-                 (setf current (if (or
-                                    (subtypep type 'double-float)
-                                    (subtypep type 'integer))
-                                     'double-float
-                                   'string)))))))
-        (collect (or current 'string))))))
+    (iter (for col in trans)
+      (collect (let ((types (assign-types-to-column col)))
+                 (cond
+                   ((member 'string types)
+                    'string)
+                   ((equal '(integer) types)
+                    'integer)
+                   ((intersection '(double-float ratio integer) types)
+                    'double-float)
+                   (t 'string)))))))
 
 (define-condition bad-type-guess (error)
   ((expected-type :reader expected-type :initarg :expected-type)

--- a/tests/data-table.lisp
+++ b/tests/data-table.lisp
@@ -68,7 +68,6 @@
                                  :rows '(("1" "2")
                                          ("3" "4")))))
 
-
     (overlay-region dt-copy1 dt-targ :row-idx 1 :col-idx 1)
     (assert-true 3 (number-of-columns dt-targ))
     (assert-true 3 (number-of-rows dt-targ))
@@ -93,6 +92,7 @@
       (assert-eql 5 (length row)))
     ;; Convert our random strings into types we can see
     (coerce-data-table-of-strings-to-types dt-targ)
+
     (assert-equal '(integer string string string integer)
         (column-types dt-targ))
     (assert-equal '(1 "2" "c" "d" 2)
@@ -204,3 +204,13 @@
                              (,(- data-table::+largest-number+ 1) integer)
                              (,(- 0 data-table::+largest-number+ 1) string)))
     (assert-eq type (data-table::simplify-types val) type val)))
+
+(define-test data-table-column-index ()
+  (let ((dt (test-data-table)))
+    (assert-eq 1 (column-index "last name" dt))
+
+    (symbolize-column-names! dt)
+
+    (assert-eq nil (column-index nil dt))
+    (assert-eq 3 (column-index 3 dt))
+    (assert-eq 1 (column-index :last-name dt))))


### PR DESCRIPTION
Fixing a few issues I found using the library.  I'd like to use the symbol names, and this should make that easier.  

Also, I tried to fix the unit tests so they pass.  There was an issue with the type guessing.